### PR TITLE
Implement multi database gateway

### DIFF
--- a/sql/dm/ruoyi-vue-pro-dm8.sql
+++ b/sql/dm/ruoyi-vue-pro-dm8.sql
@@ -302,6 +302,7 @@ CREATE TABLE infra_data_source_config (
     url varchar(1024)  NOT NULL,
     username varchar(255)  NOT NULL,
     password varchar(255) DEFAULT '' NULL,
+    type varchar(50) NOT NULL,
     creator varchar(64) DEFAULT '' NULL,
     create_time datetime DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updater varchar(64) DEFAULT '' NULL,
@@ -314,6 +315,7 @@ COMMENT ON COLUMN infra_data_source_config.name IS '参数名称';
 COMMENT ON COLUMN infra_data_source_config.url IS '数据源连接';
 COMMENT ON COLUMN infra_data_source_config.username IS '用户名';
 COMMENT ON COLUMN infra_data_source_config.password IS '密码';
+COMMENT ON COLUMN infra_data_source_config.type IS '数据库类型';
 COMMENT ON COLUMN infra_data_source_config.creator IS '创建者';
 COMMENT ON COLUMN infra_data_source_config.create_time IS '创建时间';
 COMMENT ON COLUMN infra_data_source_config.updater IS '更新者';

--- a/sql/kingbase/ruoyi-vue-pro.sql
+++ b/sql/kingbase/ruoyi-vue-pro.sql
@@ -386,6 +386,7 @@ CREATE TABLE infra_data_source_config
     url         varchar(1024) NOT NULL,
     username    varchar(255)  NOT NULL,
     password    varchar(255)  NULL     DEFAULT '',
+    type        varchar(50)   NOT NULL,
     creator     varchar(64)   NULL     DEFAULT '',
     create_time timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updater     varchar(64)   NULL     DEFAULT '',

--- a/sql/mysql/ruoyi-vue-pro.sql
+++ b/sql/mysql/ruoyi-vue-pro.sql
@@ -219,6 +219,7 @@ CREATE TABLE `infra_data_source_config`  (
   `url` varchar(1024) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '数据源连接',
   `username` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '用户名',
   `password` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '' COMMENT '密码',
+  `type` varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL COMMENT '数据库类型',
   `creator` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT '' COMMENT '创建者',
   `create_time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
   `updater` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL DEFAULT '' COMMENT '更新者',

--- a/sql/opengauss/ruoyi-vue-pro.sql
+++ b/sql/opengauss/ruoyi-vue-pro.sql
@@ -386,6 +386,7 @@ CREATE TABLE infra_data_source_config
     url         varchar(1024) NOT NULL,
     username    varchar(255)  NOT NULL,
     password    varchar(255)  NULL     DEFAULT '',
+    type        varchar(50)   NOT NULL,
     creator     varchar(64)   NULL     DEFAULT '',
     create_time timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updater     varchar(64)   NULL     DEFAULT '',

--- a/sql/oracle/ruoyi-vue-pro.sql
+++ b/sql/oracle/ruoyi-vue-pro.sql
@@ -356,6 +356,7 @@ CREATE TABLE infra_data_source_config
     url         varchar2(1024)                          NOT NULL,
     username    varchar2(255)                           NOT NULL,
     password    varchar2(255) DEFAULT ''                NULL,
+    type        varchar2(50)                           NOT NULL,
     creator     varchar2(64)  DEFAULT ''                NULL,
     create_time date          DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updater     varchar2(64)  DEFAULT ''                NULL,

--- a/sql/postgresql/ruoyi-vue-pro.sql
+++ b/sql/postgresql/ruoyi-vue-pro.sql
@@ -386,6 +386,7 @@ CREATE TABLE infra_data_source_config
     url         varchar(1024) NOT NULL,
     username    varchar(255)  NOT NULL,
     password    varchar(255)  NOT NULL DEFAULT '',
+    type        varchar(50)   NOT NULL,
     creator     varchar(64)   NULL     DEFAULT '',
     create_time timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updater     varchar(64)   NULL     DEFAULT '',

--- a/sql/sqlserver/ruoyi-vue-pro.sql
+++ b/sql/sqlserver/ruoyi-vue-pro.sql
@@ -1082,6 +1082,7 @@ CREATE TABLE infra_data_source_config
     url         nvarchar(1024)                          NOT NULL,
     username    nvarchar(255)                           NOT NULL,
     password    nvarchar(255) DEFAULT ''                NOT NULL,
+    type        nvarchar(50)                            NOT NULL,
     creator     nvarchar(64)  DEFAULT ''                NULL,
     create_time datetime2     DEFAULT CURRENT_TIMESTAMP NOT NULL,
     updater     nvarchar(64)  DEFAULT ''                NULL,
@@ -1123,6 +1124,13 @@ EXEC sp_addextendedproperty
      'SCHEMA', N'dbo',
      'TABLE', N'infra_data_source_config',
      'COLUMN', N'password'
+GO
+
+EXEC sp_addextendedproperty
+     'MS_Description', N'数据库类型',
+     'SCHEMA', N'dbo',
+     'TABLE', N'infra_data_source_config',
+     'COLUMN', N'type'
 GO
 
 EXEC sp_addextendedproperty

--- a/yudao-module-infra/yudao-module-infra-api/src/main/java/cn/iocoder/yudao/module/infra/enums/config/DatabaseTypeEnum.java
+++ b/yudao-module-infra/yudao-module-infra-api/src/main/java/cn/iocoder/yudao/module/infra/enums/config/DatabaseTypeEnum.java
@@ -1,0 +1,21 @@
+package cn.iocoder.yudao.module.infra.enums.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 数据库类型枚举
+ */
+@Getter
+@AllArgsConstructor
+public enum DatabaseTypeEnum {
+    MYSQL("mysql"),
+    SQLSERVER("sqlserver"),
+    ORACLE("oracle"),
+    POSTGRESQL("postgresql"),
+    DM("dm"),
+    KINGBASE("kingbase"),
+    MONGODB("mongodb");
+
+    private final String type;
+}

--- a/yudao-module-infra/yudao-module-infra-server/pom.xml
+++ b/yudao-module-infra/yudao-module-infra-server/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>yudao-spring-boot-starter-mybatis</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.baomidou</groupId>
             <artifactId>mybatis-plus-generator</artifactId> <!-- 代码生成器，使用它解析表结构 -->
         </dependency>

--- a/yudao-module-infra/yudao-module-infra-server/src/main/java/cn/iocoder/yudao/module/infra/controller/admin/db/vo/DataSourceConfigRespVO.java
+++ b/yudao-module-infra/yudao-module-infra-server/src/main/java/cn/iocoder/yudao/module/infra/controller/admin/db/vo/DataSourceConfigRespVO.java
@@ -2,6 +2,7 @@ package cn.iocoder.yudao.module.infra.controller.admin.db.vo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import cn.iocoder.yudao.module.infra.enums.config.DatabaseTypeEnum;
 
 import java.time.LocalDateTime;
 
@@ -20,6 +21,9 @@ public class DataSourceConfigRespVO {
 
     @Schema(description = "用户名", requiredMode = Schema.RequiredMode.REQUIRED, example = "root")
     private String username;
+
+    @Schema(description = "数据库类型", requiredMode = Schema.RequiredMode.REQUIRED, example = "mysql")
+    private DatabaseTypeEnum type;
 
     @Schema(description = "创建时间", requiredMode = Schema.RequiredMode.REQUIRED)
     private LocalDateTime createTime;

--- a/yudao-module-infra/yudao-module-infra-server/src/main/java/cn/iocoder/yudao/module/infra/controller/admin/db/vo/DataSourceConfigSaveReqVO.java
+++ b/yudao-module-infra/yudao-module-infra-server/src/main/java/cn/iocoder/yudao/module/infra/controller/admin/db/vo/DataSourceConfigSaveReqVO.java
@@ -2,6 +2,7 @@ package cn.iocoder.yudao.module.infra.controller.admin.db.vo;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
+import cn.iocoder.yudao.module.infra.enums.config.DatabaseTypeEnum;
 
 import javax.validation.constraints.NotNull;
 
@@ -27,5 +28,9 @@ public class DataSourceConfigSaveReqVO {
     @Schema(description = "密码", requiredMode = Schema.RequiredMode.REQUIRED, example = "123456")
     @NotNull(message = "密码不能为空")
     private String password;
+
+    @Schema(description = "数据库类型", requiredMode = Schema.RequiredMode.REQUIRED, example = "mysql")
+    @NotNull(message = "数据库类型不能为空")
+    private DatabaseTypeEnum type;
 
 }

--- a/yudao-module-infra/yudao-module-infra-server/src/main/java/cn/iocoder/yudao/module/infra/dal/dataobject/db/DataSourceConfigDO.java
+++ b/yudao-module-infra/yudao-module-infra-server/src/main/java/cn/iocoder/yudao/module/infra/dal/dataobject/db/DataSourceConfigDO.java
@@ -3,6 +3,7 @@ package cn.iocoder.yudao.module.infra.dal.dataobject.db;
 import cn.iocoder.yudao.framework.mybatis.core.dataobject.BaseDO;
 import cn.iocoder.yudao.framework.mybatis.core.type.EncryptTypeHandler;
 import cn.iocoder.yudao.framework.tenant.core.aop.TenantIgnore;
+import cn.iocoder.yudao.module.infra.enums.config.DatabaseTypeEnum;
 import com.baomidou.mybatisplus.annotation.KeySequence;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableName;
@@ -46,5 +47,10 @@ public class DataSourceConfigDO extends BaseDO {
      */
     @TableField(typeHandler = EncryptTypeHandler.class)
     private String password;
+
+    /**
+     * 数据库类型
+     */
+    private DatabaseTypeEnum type;
 
 }

--- a/yudao-module-infra/yudao-module-infra-server/src/main/java/cn/iocoder/yudao/module/infra/framework/mongo/MongoDbConfiguration.java
+++ b/yudao-module-infra/yudao-module-infra-server/src/main/java/cn/iocoder/yudao/module/infra/framework/mongo/MongoDbConfiguration.java
@@ -1,0 +1,24 @@
+package cn.iocoder.yudao.module.infra.framework.mongo;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+
+/**
+ * MongoDB 配置
+ */
+@Configuration
+@EnableConfigurationProperties(MongoProperties.class)
+public class MongoDbConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public MongoClient mongoClient(MongoProperties properties) {
+        return MongoClients.create(properties.getUri());
+    }
+}
+

--- a/yudao-module-infra/yudao-module-infra-server/src/main/java/cn/iocoder/yudao/module/infra/service/db/DataSourceConfigServiceImpl.java
+++ b/yudao-module-infra/yudao-module-infra-server/src/main/java/cn/iocoder/yudao/module/infra/service/db/DataSourceConfigServiceImpl.java
@@ -5,6 +5,7 @@ import cn.iocoder.yudao.framework.mybatis.core.util.JdbcUtils;
 import cn.iocoder.yudao.module.infra.controller.admin.db.vo.DataSourceConfigSaveReqVO;
 import cn.iocoder.yudao.module.infra.dal.dataobject.db.DataSourceConfigDO;
 import cn.iocoder.yudao.module.infra.dal.mysql.db.DataSourceConfigMapper;
+import cn.iocoder.yudao.module.infra.enums.config.DatabaseTypeEnum;
 import com.baomidou.dynamic.datasource.creator.DataSourceProperty;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceProperties;
 import org.springframework.stereotype.Service;
@@ -32,6 +33,25 @@ public class DataSourceConfigServiceImpl implements DataSourceConfigService {
 
     @Resource
     private DynamicDataSourceProperties dynamicDataSourceProperties;
+
+    private DatabaseTypeEnum parseDatabaseType(String url) {
+        switch (JdbcUtils.getDbType(url)) {
+            case ORACLE:
+                return DatabaseTypeEnum.ORACLE;
+            case SQL_SERVER:
+            case SQL_SERVER2005:
+                return DatabaseTypeEnum.SQLSERVER;
+            case POSTGRE_SQL:
+                return DatabaseTypeEnum.POSTGRESQL;
+            case DM:
+                return DatabaseTypeEnum.DM;
+            case KINGBASE_ES:
+                return DatabaseTypeEnum.KINGBASE;
+            case MYSQL:
+            default:
+                return DatabaseTypeEnum.MYSQL;
+        }
+    }
 
     @Override
     public Long createDataSourceConfig(DataSourceConfigSaveReqVO createReqVO) {
@@ -100,7 +120,8 @@ public class DataSourceConfigServiceImpl implements DataSourceConfigService {
         return new DataSourceConfigDO().setId(DataSourceConfigDO.ID_MASTER).setName(primary)
                 .setUrl(dataSourceProperty.getUrl())
                 .setUsername(dataSourceProperty.getUsername())
-                .setPassword(dataSourceProperty.getPassword());
+                .setPassword(dataSourceProperty.getPassword())
+                .setType(parseDatabaseType(dataSourceProperty.getUrl()));
     }
 
 }

--- a/yudao-module-infra/yudao-module-infra-server/src/test/java/cn/iocoder/yudao/module/infra/service/db/DataSourceConfigServiceImplTest.java
+++ b/yudao-module-infra/yudao-module-infra-server/src/test/java/cn/iocoder/yudao/module/infra/service/db/DataSourceConfigServiceImplTest.java
@@ -9,6 +9,7 @@ import cn.iocoder.yudao.framework.test.core.ut.BaseDbUnitTest;
 import cn.iocoder.yudao.module.infra.controller.admin.db.vo.DataSourceConfigSaveReqVO;
 import cn.iocoder.yudao.module.infra.dal.dataobject.db.DataSourceConfigDO;
 import cn.iocoder.yudao.module.infra.dal.mysql.db.DataSourceConfigMapper;
+import cn.iocoder.yudao.module.infra.enums.config.DatabaseTypeEnum;
 import com.baomidou.dynamic.datasource.creator.DataSourceProperty;
 import com.baomidou.dynamic.datasource.spring.boot.autoconfigure.DynamicDataSourceProperties;
 import org.junit.jupiter.api.BeforeEach;
@@ -168,6 +169,7 @@ public class DataSourceConfigServiceImplTest extends BaseDbUnitTest {
         assertEquals("http://localhost:3306", dataSourceConfig.getUrl());
         assertEquals("yunai", dataSourceConfig.getUsername());
         assertEquals("tudou", dataSourceConfig.getPassword());
+        assertEquals(DatabaseTypeEnum.MYSQL, dataSourceConfig.getType());
     }
 
     @Test
@@ -201,6 +203,7 @@ public class DataSourceConfigServiceImplTest extends BaseDbUnitTest {
         assertEquals("http://localhost:3306", dataSourceConfigList.get(0).getUrl());
         assertEquals("yunai", dataSourceConfigList.get(0).getUsername());
         assertEquals("tudou", dataSourceConfigList.get(0).getPassword());
+        assertEquals(DatabaseTypeEnum.MYSQL, dataSourceConfigList.get(0).getType());
         // normal
         assertPojoEquals(dbDataSourceConfig, dataSourceConfigList.get(1));
     }

--- a/yudao-module-infra/yudao-module-infra-server/src/test/resources/sql/create_tables.sql
+++ b/yudao-module-infra/yudao-module-infra-server/src/test/resources/sql/create_tables.sql
@@ -152,6 +152,7 @@ CREATE TABLE IF NOT EXISTS "infra_data_source_config" (
     "url" varchar(1024) NOT NULL,
     "username" varchar(255) NOT NULL,
     "password" varchar(255) NOT NULL,
+    "type" varchar(50) NOT NULL,
     "creator" varchar(64) DEFAULT '',
     "create_time" datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updater" varchar(64) DEFAULT '',


### PR DESCRIPTION
## Summary
- add database type enum
- store database type in datasource configuration
- parse database type from URL
- support MongoDB with simple configuration
- include type in datasource REST models
- update SQL schemas for `type` column

## Testing
- `mvn -v` *(fails: command not found)*